### PR TITLE
Improvements to user creation and startup

### DIFF
--- a/DjangoLibrary/tests/autologin.robot
+++ b/DjangoLibrary/tests/autologin.robot
@@ -8,7 +8,7 @@ ${BROWSER}              firefox
 
 Documentation   Django Robot Tests
 Library         Selenium2Library  timeout=10  implicit_wait=0
-Library         DjangoLibrary  127.0.0.1  55001
+Library         DjangoLibrary  127.0.0.1  55001  path=mysite/mysite  manage=mysite/manage.py  settings=mysite.settings  db=mysite/db.sqlite3
 Suite Setup     Start Django and Open Browser
 Suite Teardown  Stop Django and Close Browser
 

--- a/DjangoLibrary/tests/test_selenium_bug_4198.robot.disabled
+++ b/DjangoLibrary/tests/test_selenium_bug_4198.robot.disabled
@@ -8,7 +8,7 @@ ${BROWSER}              firefox
 
 Documentation   Django Robot Tests
 Library         Selenium2Library  timeout=10  implicit_wait=0
-Library         DjangoLibrary  127.0.0.1  55001
+Library         DjangoLibrary  127.0.0.1  55001  path=mysite/mysite  manage=mysite/manage.py  settings=mysite.settings  db=mysite/db.sqlite3
 Suite Setup     Start Django and Open Browser
 Suite Teardown  Stop Django and Close Browser
 


### PR DESCRIPTION
I've removed some of the hard-coded paths to make it more easily configurable from .robot files, and modified the user creation logic to call into manage.py instead of importing the DB manually, as this allows multiple instances to set-up and tear-down.

Note, I used `manage.py shell` instead of `manage.py createsuperuser` as the latter fails when not run from a tty.
