### PR TITLE
Replace deprecated method on start_django keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Remove deprecated method from internal startup flow.
 
 
 1.2 (2016-07-08)

--- a/DjangoLibrary/__init__.py
+++ b/DjangoLibrary/__init__.py
@@ -172,7 +172,7 @@ user.save()""".format(
 
     def start_django(self):
         """Start the Django server."""
-        self.clear_db()
+        self.manage_flush()
         self.manage_makemigrations()
         self.manage_migrate()
         logger.console("-" * 78)


### PR DESCRIPTION
I followed the instructions to run the initial test on your docs. It worked as expected, however there was a deprecation warning about the "clear_db" method. All that method did was raise the deprecation notice and use "manage_flush" internally, so i replaced it to avoid the warning.
