### PR TITLE
Use the proper user model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 ----------------
 
 - Remove deprecated method from internal startup flow.
+- Use AUTH_MODEL to create user instead of django's default
 
 
 1.2 (2016-07-08)

--- a/DjangoLibrary/__init__.py
+++ b/DjangoLibrary/__init__.py
@@ -133,8 +133,8 @@ class DjangoLibrary:
         "is_staff=True")."""
 
         to_run = """
-from django.contrib.auth.models import User
-user = User.objects.create_user(
+from django.contrib.auth import get_user_model
+user = get_user_model().objects.create_user(
     '{0}',
     email='{1}',
     password='{2}',


### PR DESCRIPTION
create_user was using django's default user model. Most projects to this date extend beyond that model and use something else. That model is indicated with the setting AUTH_MODEL.
This change uses that model instead of the default one. Should not affect functionality for users that require django's contrib auth model.
